### PR TITLE
Add development workflow agents

### DIFF
--- a/adhd-focus-hub/dev_agents/__init__.py
+++ b/adhd-focus-hub/dev_agents/__init__.py
@@ -1,0 +1,21 @@
+"""Development workflow agents."""
+
+from .base import BaseDevAgent
+from .backend_architect import BackendArchitect
+from .frontend_architect import FrontendArchitect
+from .backend_developer import BackendDeveloper
+from .frontend_developer import FrontendDeveloper
+from .testing_engineer import TestingEngineer
+from .integration_engineer import IntegrationEngineer
+from .project_manager import ProjectManager
+
+__all__ = [
+    "BaseDevAgent",
+    "BackendArchitect",
+    "FrontendArchitect",
+    "BackendDeveloper",
+    "FrontendDeveloper",
+    "TestingEngineer",
+    "IntegrationEngineer",
+    "ProjectManager",
+]

--- a/adhd-focus-hub/dev_agents/backend_architect.py
+++ b/adhd-focus-hub/dev_agents/backend_architect.py
@@ -1,0 +1,24 @@
+"""Backend architecture specialist."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class BackendArchitect(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Backend Architect",
+            goal="Design scalable backend systems and APIs",
+            backstory=dedent(
+                """
+                You are an experienced software architect focusing on backend
+                services. You ensure code is maintainable, well-tested and
+                follows best practices.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/backend_developer.py
+++ b/adhd-focus-hub/dev_agents/backend_developer.py
@@ -1,0 +1,23 @@
+"""Backend development agent."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class BackendDeveloper(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Backend Developer",
+            goal="Implement backend features and fix bugs",
+            backstory=dedent(
+                """
+                You implement API endpoints, database models and business logic.
+                You keep the codebase clean and write unit tests where needed.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/base.py
+++ b/adhd-focus-hub/dev_agents/base.py
@@ -1,0 +1,69 @@
+"""Base class for development workflow agents."""
+
+from crewai import Agent
+from typing import Dict, Any, List
+from datetime import datetime
+
+
+class BaseDevAgent:
+    """General-purpose agent with simple context tracking."""
+
+    def __init__(self, role: str, goal: str, backstory: str, tools: List = None, llm=None, **kwargs):
+        # Underlying CrewAI agent
+        self.agent = Agent(
+            role=role,
+            goal=goal,
+            backstory=backstory,
+            tools=tools or [],
+            verbose=True,
+            allow_delegation=False,
+            llm=llm,
+            **kwargs,
+        )
+
+        self.conversation_history: List[Dict[str, Any]] = []
+        self.context: Dict[str, Any] = {}
+
+        self.role = self.agent.role
+        self.goal = self.agent.goal
+        self.backstory = self.agent.backstory
+
+    def execute_with_context(self, task_description: str, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Execute a task using stored context."""
+        if context:
+            self.context.update(context)
+
+        prompt = self._build_contextual_prompt(task_description, self.context)
+        response = self._process_request(prompt)
+
+        result = {
+            "agent": self.role,
+            "response": response,
+            "context_used": self.context,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+
+        self.conversation_history.append({
+            "input": task_description,
+            "output": result,
+            "timestamp": datetime.utcnow().isoformat(),
+        })
+        return result
+
+    def _build_contextual_prompt(self, task: str, context: Dict[str, Any]) -> str:
+        prompt_parts = [f"Task: {task}", "", "Context:"]
+        for key, value in context.items():
+            prompt_parts.append(f"- {key}: {value}")
+        if self.conversation_history:
+            recent = self.conversation_history[-1]
+            prompt_parts.append(f"- Recent interaction: {recent['input'][:100]}...")
+        prompt_parts.append("\nProvide guidance to complete the task.")
+        return "\n".join(prompt_parts)
+
+    def _process_request(self, prompt: str) -> str:
+        """Placeholder processing method."""
+        return f"[{self.role}] {prompt[:100]}"
+
+    def get_specialized_tools(self) -> List:
+        """Return tools specific to this agent."""
+        return []

--- a/adhd-focus-hub/dev_agents/entry.py
+++ b/adhd-focus-hub/dev_agents/entry.py
@@ -1,0 +1,30 @@
+"""Entry point for loading development workflow agents with Codex."""
+
+from . import (
+    BackendArchitect,
+    FrontendArchitect,
+    BackendDeveloper,
+    FrontendDeveloper,
+    TestingEngineer,
+    IntegrationEngineer,
+    ProjectManager,
+)
+
+
+def load() -> dict:
+    """Return instantiated agents for Codex."""
+    return {
+        "backend_architect": BackendArchitect(),
+        "frontend_architect": FrontendArchitect(),
+        "backend_developer": BackendDeveloper(),
+        "frontend_developer": FrontendDeveloper(),
+        "testing_engineer": TestingEngineer(),
+        "integration_engineer": IntegrationEngineer(),
+        "project_manager": ProjectManager(),
+    }
+
+
+if __name__ == "__main__":
+    agents = load()
+    for name, agent in agents.items():
+        print(f"Loaded {name}: {agent.role}")

--- a/adhd-focus-hub/dev_agents/frontend_architect.py
+++ b/adhd-focus-hub/dev_agents/frontend_architect.py
@@ -1,0 +1,24 @@
+"""Frontend architecture specialist."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class FrontendArchitect(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Frontend Architect",
+            goal="Design efficient frontend applications and component systems",
+            backstory=dedent(
+                """
+                You architect modern web frontends with an eye for usability and
+                maintainability. You set guidelines for component reuse and
+                performance.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/frontend_developer.py
+++ b/adhd-focus-hub/dev_agents/frontend_developer.py
@@ -1,0 +1,23 @@
+"""Frontend development agent."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class FrontendDeveloper(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Frontend Developer",
+            goal="Build and maintain the user interface",
+            backstory=dedent(
+                """
+                You develop responsive user interfaces and ensure cross-browser
+                compatibility. Accessibility and performance guide your work.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/integration_engineer.py
+++ b/adhd-focus-hub/dev_agents/integration_engineer.py
@@ -1,0 +1,24 @@
+"""Integration agent handling CI/CD and system cohesion."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class IntegrationEngineer(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Integration Engineer",
+            goal="Manage CI/CD pipelines and integrate services",
+            backstory=dedent(
+                """
+                You coordinate infrastructure, deployment pipelines and
+                service integration. You ensure components work together
+                smoothly across environments.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/project_manager.py
+++ b/adhd-focus-hub/dev_agents/project_manager.py
@@ -1,0 +1,24 @@
+"""Project management agent."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class ProjectManager(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Project Manager",
+            goal="Coordinate tasks and timelines for the dev team",
+            backstory=dedent(
+                """
+                You keep the project on track by prioritizing work and
+                communicating status. You help remove blockers for the
+                developers and keep stakeholders informed.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/testing_engineer.py
+++ b/adhd-focus-hub/dev_agents/testing_engineer.py
@@ -1,0 +1,23 @@
+"""Quality assurance and testing agent."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class TestingEngineer(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Testing Engineer",
+            goal="Ensure the application is well tested and reliable",
+            backstory=dedent(
+                """
+                You focus on automated testing and code quality. You write unit
+                and integration tests and report issues clearly to the team.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []


### PR DESCRIPTION
## Summary
- add `dev_agents` package for codex-driven development workflows
- implement base class with context handling
- create backend/frontend architects, developers, testing, integration and project management agents
- expose an entry script for Codex to load the agents

## Testing
- `PYTHONPATH=backend python test_tools.py` *(fails: TimeEstimationTool._run() got an unexpected keyword argument 'user_experience')*

------
https://chatgpt.com/codex/tasks/task_e_6882649fd7588329af19e456075d250c