### PR TITLE
Align dev agents with docs

### DIFF
--- a/adhd-focus-hub/dev_agents/__init__.py
+++ b/adhd-focus-hub/dev_agents/__init__.py
@@ -1,21 +1,17 @@
 """Development workflow agents."""
 
 from .base import BaseDevAgent
-from .backend_architect import BackendArchitect
-from .frontend_architect import FrontendArchitect
 from .backend_developer import BackendDeveloper
 from .frontend_developer import FrontendDeveloper
-from .testing_engineer import TestingEngineer
-from .integration_engineer import IntegrationEngineer
-from .project_manager import ProjectManager
+from .lead_planner import LeadPlanner
+from .qa_tester import QATester
+from .docs_writer import DocsWriter
 
 __all__ = [
     "BaseDevAgent",
-    "BackendArchitect",
-    "FrontendArchitect",
+    "LeadPlanner",
     "BackendDeveloper",
     "FrontendDeveloper",
-    "TestingEngineer",
-    "IntegrationEngineer",
-    "ProjectManager",
+    "QATester",
+    "DocsWriter",
 ]

--- a/adhd-focus-hub/dev_agents/docs_writer.py
+++ b/adhd-focus-hub/dev_agents/docs_writer.py
@@ -1,0 +1,24 @@
+"""Documentation writer agent."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class DocsWriter(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Docs Writer",
+            goal="Update project documentation and READMEs",
+            backstory=dedent(
+                """
+                You craft and maintain clear, concise documentation for the
+                project. You ensure setup guides, contribution docs, and API
+                references are easy to follow.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/entry.py
+++ b/adhd-focus-hub/dev_agents/entry.py
@@ -1,26 +1,22 @@
 """Entry point for loading development workflow agents with Codex."""
 
 from . import (
-    BackendArchitect,
-    FrontendArchitect,
     BackendDeveloper,
     FrontendDeveloper,
-    TestingEngineer,
-    IntegrationEngineer,
-    ProjectManager,
+    LeadPlanner,
+    QATester,
+    DocsWriter,
 )
 
 
 def load() -> dict:
     """Return instantiated agents for Codex."""
     return {
-        "backend_architect": BackendArchitect(),
-        "frontend_architect": FrontendArchitect(),
+        "lead_planner": LeadPlanner(),
         "backend_developer": BackendDeveloper(),
         "frontend_developer": FrontendDeveloper(),
-        "testing_engineer": TestingEngineer(),
-        "integration_engineer": IntegrationEngineer(),
-        "project_manager": ProjectManager(),
+        "qa_tester": QATester(),
+        "docs_writer": DocsWriter(),
     }
 
 

--- a/adhd-focus-hub/dev_agents/lead_planner.py
+++ b/adhd-focus-hub/dev_agents/lead_planner.py
@@ -1,0 +1,24 @@
+"""Lead Planner agent for feature breakdown and roadmapping."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class LeadPlanner(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="Lead Planner",
+            goal="Break down features and create implementation roadmaps",
+            backstory=dedent(
+                """
+                You collaborate with the team to plan new features.
+                Your strength is decomposing big ideas into actionable tasks
+                with realistic timelines and clear priorities.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []

--- a/adhd-focus-hub/dev_agents/qa_tester.py
+++ b/adhd-focus-hub/dev_agents/qa_tester.py
@@ -1,0 +1,24 @@
+"""QA Tester agent responsible for running automated tests."""
+
+from textwrap import dedent
+from .base import BaseDevAgent
+
+
+class QATester(BaseDevAgent):
+    def __init__(self, llm=None):
+        super().__init__(
+            role="QA Tester",
+            goal="Execute unit tests and report results",
+            backstory=dedent(
+                """
+                You ensure the codebase remains reliable by writing and running
+                automated tests. You communicate failures clearly and help
+                maintain overall quality.
+                """
+            ),
+            tools=self.get_specialized_tools(),
+            llm=llm,
+        )
+
+    def get_specialized_tools(self):
+        return []


### PR DESCRIPTION
## Summary
- clean up exports to match documented dev agents
- reinstall flake8 to rerun blocked request

## Testing
- `python -m py_compile adhd-focus-hub/dev_agents/*.py`
- `python adhd-focus-hub/test_tools.py`
- `flake8 adhd-focus-hub/dev_agents | head`

------
https://chatgpt.com/codex/tasks/task_e_68827577232083298826150192880561