### PR TITLE
Add AGENT.md instructions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,38 @@
+# Development Agents for Codex
+
+This repository uses CrewAI-based development agents located in `adhd-focus-hub/dev_agents/`. They streamline planning, implementation, and testing when working with Codex.
+
+## Agents
+
+| Agent | Role |
+|-------|------|
+| **LeadPlanner** | Break down features and create a roadmap. |
+| **BackendDeveloper** | Work on the FastAPI backend. |
+| **FrontendDeveloper** | Implement the React/TypeScript frontend. |
+| **QATester** | Execute tests and report results. |
+| **DocsWriter** | Update project documentation. |
+
+## Usage
+
+Before running any agents, set your `OPENAI_API_KEY` environment variable:
+```bash
+export OPENAI_API_KEY=your_openai_api_key
+```
+
+Start Codex with any combination of these agents. Example:
+
+```bash
+codex agents start LeadPlanner BackendDeveloper FrontendDeveloper QATester DocsWriter
+```
+
+The agents are imported from the `adhd_focus_hub.dev_agents` package.
+
+## Testing
+
+After code changes, run:
+
+```bash
+python adhd-focus-hub/test_tools.py
+```
+
+Include the output of this script in your pull request summary.

--- a/adhd-focus-hub/README.md
+++ b/adhd-focus-hub/README.md
@@ -282,7 +282,7 @@ npm run lint
 
 ## Development Agents
 
-See [DEV_AGENTS.md](../DEV_AGENTS.md) for a list of Codex development agents, how to start them, and example workflows.
+See [AGENT.md](../AGENT.md) for a list of Codex development agents, how to start them, and example workflows.
 
 ## 🚀 Deployment
 


### PR DESCRIPTION
## Summary
- rename `agent.md` to `AGENT.md`
- document how to set `OPENAI_API_KEY` before starting CrewAI dev agents
- reference the new `AGENT.md` from the project README

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68827cc1cf1c8329a6b4c35574b06618