### PR TITLE
Implement auth and DB models

### DIFF
--- a/adhd-focus-hub/backend/.env.example
+++ b/adhd-focus-hub/backend/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=your-openai-api-key
+DATABASE_URL=postgresql+asyncpg://postgres:password@localhost:5432/adhd_focus_hub
+REDIS_URL=redis://localhost:6379/0
+SECRET_KEY=change-me

--- a/adhd-focus-hub/backend/alembic.ini
+++ b/adhd-focus-hub/backend/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = env:DATABASE_URL
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/adhd-focus-hub/backend/api/models.py
+++ b/adhd-focus-hub/backend/api/models.py
@@ -6,6 +6,21 @@ from datetime import datetime
 from enum import Enum
 
 
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserCreate(BaseModel):
+    username: str = Field(..., min_length=3, max_length=100)
+    password: str = Field(..., min_length=6)
+
+
+class UserLogin(BaseModel):
+    username: str
+    password: str
+
+
 class TaskPriority(str, Enum):
     """Task priority levels."""
     low = "low"
@@ -76,6 +91,22 @@ class TaskBreakdownResponse(BaseModel):
     recommended_focus_sessions: int = Field(..., description="Recommended number of focus sessions")
 
 
+class TaskCreate(BaseModel):
+    title: str
+    description: Optional[str] = None
+
+
+class TaskOut(BaseModel):
+    id: int
+    title: str
+    description: Optional[str] = None
+    completed: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 # Focus Session Models
 class FocusSessionRequest(BaseModel):
     """Request for focus session."""
@@ -127,6 +158,16 @@ class MoodCheckResponse(BaseModel):
     recommended_activities: List[str] = Field(default=[], description="Suggested activities")
     escalation_needed: bool = Field(default=False, description="Whether professional help is recommended")
     follow_up_time: Optional[datetime] = Field(default=None, description="Recommended follow-up time")
+
+
+class MoodLogOut(BaseModel):
+    id: int
+    mood_score: int
+    notes: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
 
 
 # Organization Models

--- a/adhd-focus-hub/backend/database/__init__.py
+++ b/adhd-focus-hub/backend/database/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.orm import DeclarativeBase
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+class Base(DeclarativeBase):
+    pass
+
+async def get_db() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session

--- a/adhd-focus-hub/backend/database/models.py
+++ b/adhd-focus-hub/backend/database/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from sqlalchemy import Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from . import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    username: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(256))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    tasks: Mapped[list[Task]] = relationship("Task", back_populates="owner")
+    moods: Mapped[list[MoodLog]] = relationship("MoodLog", back_populates="owner")
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    title: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(String(1000))
+    completed: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    owner: Mapped[User] = relationship("User", back_populates="tasks")
+
+class MoodLog(Base):
+    __tablename__ = "mood_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    owner_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    mood_score: Mapped[int] = mapped_column(Integer)
+    notes: Mapped[str | None] = mapped_column(String(1000))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    owner: Mapped[User] = relationship("User", back_populates="moods")

--- a/adhd-focus-hub/backend/migrations/env.py
+++ b/adhd-focus-hub/backend/migrations/env.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from database import Base  # noqa
+from database.models import *  # noqa
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    url = os.getenv("DATABASE_URL")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/adhd-focus-hub/backend/migrations/versions/0001_initial.py
+++ b/adhd-focus-hub/backend/migrations/versions/0001_initial.py
@@ -1,0 +1,42 @@
+"""initial tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('username', sa.String(length=100), nullable=False, unique=True),
+        sa.Column('hashed_password', sa.String(length=256), nullable=False),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+    )
+    op.create_table(
+        'tasks',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('owner_id', sa.Integer, sa.ForeignKey('users.id')),
+        sa.Column('title', sa.String(length=200)),
+        sa.Column('description', sa.String(length=1000)),
+        sa.Column('completed', sa.Boolean, default=False),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+    )
+    op.create_table(
+        'mood_logs',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('owner_id', sa.Integer, sa.ForeignKey('users.id')),
+        sa.Column('mood_score', sa.Integer),
+        sa.Column('notes', sa.String(length=1000)),
+        sa.Column('created_at', sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('mood_logs')
+    op.drop_table('tasks')
+    op.drop_table('users')


### PR DESCRIPTION
## Summary
- add `.env.example` for backend environment variables
- load local `.env` in FastAPI main module
- implement database module with SQLAlchemy and Alembic migrations
- add JWT auth utilities and CRUD endpoints
- expose new task and mood APIs

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6882878e1d1083299a4c2ce17274eb0a