### PR TITLE
Update error handling and db test fixture

### DIFF
--- a/adhd-focus-hub/backend/api/main.py
+++ b/adhd-focus-hub/backend/api/main.py
@@ -2,6 +2,7 @@
 
 from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from contextlib import asynccontextmanager
@@ -560,10 +561,12 @@ async def http_exception_handler(request, exc):
     """Handle HTTP exceptions."""
     return JSONResponse(
         status_code=exc.status_code,
-        content=ErrorResponse(
-            detail=exc.detail,
-            error_code=str(exc.status_code),
-        ).model_dump(),
+        content=jsonable_encoder(
+            ErrorResponse(
+                detail=exc.detail,
+                error_code=str(exc.status_code),
+            )
+        ),
     )
 
 
@@ -573,10 +576,12 @@ async def general_exception_handler(request, exc):
     logger.error(f"Unhandled exception: {exc}")
     return JSONResponse(
         status_code=500,
-        content=ErrorResponse(
-            detail="An unexpected error occurred. Please try again later.",
-            error_code="500",
-        ).model_dump(),
+        content=jsonable_encoder(
+            ErrorResponse(
+                detail="An unexpected error occurred. Please try again later.",
+                error_code="500",
+            )
+        ),
     )
 
 

--- a/adhd-focus-hub/tests/test_api.py
+++ b/adhd-focus-hub/tests/test_api.py
@@ -11,14 +11,19 @@ from backend.database import Base, engine, SessionLocal
 
 @pytest.fixture(autouse=True, scope="module")
 def setup_db():
+    """Create and tear down database tables for tests."""
+    import asyncio
+    if os.path.exists("/tmp/test.db"):
+        os.remove("/tmp/test.db")
+
     async def init_db():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
+
     async def teardown():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
 
-    import asyncio
     asyncio.run(init_db())
     yield
     asyncio.run(teardown())


### PR DESCRIPTION
## Summary
- fix FastAPI error handlers to use `jsonable_encoder`
- tweak database setup fixture in API tests

## Testing
- `python adhd-focus-hub/test_tools.py` *(fails: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_688295e9a1208329b0ed08f1fcf442f5