### PR TITLE
Add database initialization script

### DIFF
--- a/adhd-focus-hub/backend/database/init.sql
+++ b/adhd-focus-hub/backend/database/init.sql
@@ -1,0 +1,24 @@
+CREATE TABLE users (
+    id SERIAL PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    hashed_password VARCHAR(256) NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE tasks (
+    id SERIAL PRIMARY KEY,
+    owner_id INTEGER REFERENCES users(id),
+    title VARCHAR(200),
+    description VARCHAR(1000),
+    completed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE mood_logs (
+    id SERIAL PRIMARY KEY,
+    owner_id INTEGER REFERENCES users(id),
+    mood_score INTEGER,
+    notes VARCHAR(1000),
+    created_at TIMESTAMP NOT NULL
+);
+


### PR DESCRIPTION
## Summary
- provide `backend/database/init.sql` with CREATE TABLE statements
- run `adhd-focus-hub/test_tools.py`

## Testing
- `python adhd-focus-hub/test_tools.py` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_6882a362242083299e2c2256875538de