### PR TITLE
Add backend settings module and update env defaults

### DIFF
--- a/adhd-focus-hub/backend/api/main.py
+++ b/adhd-focus-hub/backend/api/main.py
@@ -12,14 +12,18 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+import backend.database.models  # ensure models are registered
 from api.models import ErrorResponse, HealthResponse
 from backend.database import get_db
-import backend.database.models  # ensure models are registered
+from config.settings import get_settings
 from crew.crew import ADHDFocusHubCrew
 
 # Load environment variables from backend/.env if present
 env_path = Path(__file__).resolve().parent.parent / ".env"
 load_dotenv(env_path)
+
+# Load application settings
+settings = get_settings()
 
 # Add the parent directory to the path to resolve imports
 sys.path.append(str(Path(__file__).parent.parent))
@@ -96,8 +100,8 @@ async def health_check():
 
 from .routes.auth import router as auth_router
 from .routes.chat import router as chat_router
-from .routes.tasks import router as tasks_router
 from .routes.mood import router as mood_router
+from .routes.tasks import router as tasks_router
 
 app.include_router(auth_router)
 app.include_router(chat_router)

--- a/adhd-focus-hub/backend/config/settings.py
+++ b/adhd-focus-hub/backend/config/settings.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment or .env file."""
+
+    openai_api_key: str | None = None
+    openai_base_url: str = "https://api.perplexity.ai"
+    openai_model: str = "llama-3.1-sonar-small-128k-online"
+
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
+    redis_url: str = "redis://localhost:6379/0"
+
+    secret_key: str = "secret"
+    access_token_expire_minutes: int = 60
+
+    model_config = SettingsConfigDict(
+        env_file=str(Path(__file__).resolve().parents[1] / ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+    return Settings()

--- a/adhd-focus-hub/backend/database/__init__.py
+++ b/adhd-focus-hub/backend/database/__init__.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.orm import DeclarativeBase
-import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
+from config.settings import get_settings
+
+settings = get_settings()
+DATABASE_URL = settings.database_url
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
+
 class Base(DeclarativeBase):
     pass
+
 
 async def get_db() -> AsyncSession:
     async with SessionLocal() as session:


### PR DESCRIPTION
## Summary
- create `backend/config/settings.py` with `BaseSettings`
- load settings in `api/main.py`
- use settings in DB init and default to async Postgres
- run unit tests

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6883057e3d28832992f479cd8117f15b