### PR TITLE
Add production compose

### DIFF
--- a/adhd-focus-hub/README.md
+++ b/adhd-focus-hub/README.md
@@ -102,6 +102,13 @@ The application will be available at:
 - Backend API: http://localhost:8000
 - API Documentation: http://localhost:8000/docs
 
+The default `docker-compose.yml` is optimized for local development. It mounts
+the source code into the containers and enables automatic reloads when files
+change. For a production deployment, use
+`docker-compose.production.yml` which builds the images once and runs them
+without any source-code volumes. All configuration values should be supplied via
+environment variables.
+
 ## 🏗️ Project Structure
 
 ```
@@ -294,6 +301,9 @@ See [AGENT.md](../AGENT.md) for a list of Codex development agents, how to start
 # Build and run production containers
 docker-compose -f docker-compose.production.yml up --build -d
 ```
+This compose file uses the Docker images defined in the repository and does not
+mount the application source code. Provide all secrets and URLs through
+environment variables before running the stack.
 
 ### Manual Deployment
 1. **Backend**: Deploy to Railway, Render, or similar Python hosting

--- a/adhd-focus-hub/docker-compose.production.yml
+++ b/adhd-focus-hub/docker-compose.production.yml
@@ -1,0 +1,54 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: adhd_focus_hub_frontend:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=${REACT_APP_API_URL}
+      - REACT_APP_VERSION=${REACT_APP_VERSION:-1.0.0}
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    image: adhd_focus_hub_backend:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - SECRET_KEY=${SECRET_KEY}
+      - ENVIRONMENT=production
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-adhd_focus_hub}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  redis_data:


### PR DESCRIPTION
## Summary
- add `docker-compose.production.yml` using built images
- explain difference between development and production Docker setups
- document how to run production compose file

## Testing
- `PYTHONPATH=learning_ai/adhd-focus-hub/backend python learning_ai/adhd-focus-hub/test_tools.py` *(fails: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_6882a3915094832986c476f44284c05e