### PR TITLE
Fix roadmap numbering

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,17 +6,12 @@ Each milestone is ordered by priority with an estimated time to complete.
 
 | Priority | Milestone | Key Tasks | Deliverables | Success Criteria | Est. Time | Status |
 |---------|----------|-----------|--------------|-----------------|-----------|--------|
-| 1 | **Environment Setup** | - Create `backend/.env.example` with required variables.<br>- Document local setup in README.<br>- Add real `.env` locally with `OPENAI_API_KEY`. | Sample `.env.example` file and updated docs. | Backend runs with environment variables loaded. | 0.5 day | ✅ Completed |
-| 2 | **CrewAI Tool Fixes** | - Review tools in `backend/crew/tools/` for Pydantic v2 issues.<br>- Update models/functions for compatibility.<br>- Run `python adhd-focus-hub/test_tools.py`. | Updated tool code and passing tests. | Test script outputs success for all tools. | 1 day | ✅ Completed |
-| 3 | **Database Layer** | - Set up SQLAlchemy models (User, Task, MoodLog).<br>- Configure PostgreSQL via `DATABASE_URL`.<br>- Create Alembic migrations.<br>- Document setup in README. | Database models and migrations committed. | Migrations run without errors and tables created. | 2 days | ✅ Completed |
-| 4 | **Authentication** | - Implement JWT-based auth in FastAPI.<br>- Protect endpoints with `HTTPBearer`.<br>- Create login/register routes.<br>- Add token storage in frontend. | Auth API and middleware. | Login and protected routes work with valid tokens. | 2 days | ✅ Completed |
-| 5 | **Frontend Integration** | - Update services in `frontend/src/services` to call backend APIs with auth tokens.<br>- Build login and registration pages.<br>- Connect task and mood pages to backend. | Working frontend communicating with backend. | Users can authenticate and CRUD data from UI. | 2 days | ✅ Completed |
-| 6 | **Comprehensive Testing** | - Expand `test_tools.py` into pytest suite.<br>- Cover all API endpoints and auth flow.<br>- Add CI instructions. | Pytest tests under `tests/` directory. | Test suite passes locally and in CI. | 1.5 days | ✅ Completed |
-| 7 | **Deployment** | - Create Docker compose for backend/frontend.<br>- Document deployment steps.<br>- Push images to container registry. | Dockerfiles and compose config for production. | Application deploys successfully on staging environment. | 1.5 days | ⏳ Pending |
+| 1 | **Orchestrator Alignment** | - Refactor `OrchestratorAgent` to extend `BaseADHDAgent`.<br>- Add context storage and conversation history.<br>- Update crew integration and unit tests. | Unified orchestrator with base features. | Tests confirm orchestration with stored context. | 1 day | ⏳ Pending |
+| 2 | **Deployment** | - Create Docker compose for backend/frontend.<br>- Document deployment steps.<br>- Push images to container registry. | Dockerfiles and compose config for production. | Application deploys successfully on staging environment. | 1.5 days | ⏳ Pending |
 
 ## Timeline Overview
 
-Milestones 1–6 are complete. The remaining work for deployment totals approximately **1.5 days**. Adjust as necessary based on team availability.
+Milestones 1–6 are complete. Orchestrator alignment and deployment remain, totaling approximately **2.5 days** of work. Adjust as necessary based on team availability.
 
 ## Usage by Agents
 
@@ -29,3 +24,14 @@ Milestones 1–6 are complete. The remaining work for deployment totals approxim
 - **IntegrationEngineer** manages CI/CD pipelines for smooth releases.
 
 This roadmap should keep all agents aligned as the project progresses.
+
+## Implemented
+
+| Priority | Milestone | Key Tasks | Deliverables | Success Criteria | Est. Time | Status |
+|---------|----------|-----------|--------------|-----------------|-----------|-------|
+| 1 | **Environment Setup** | - Create `backend/.env.example` with required variables.<br>- Document local setup in README.<br>- Add real `.env` locally with `OPENAI_API_KEY`. | Sample `.env.example` file and updated docs. | Backend runs with environment variables loaded. | 0.5 day | ✅ Completed |
+| 2 | **CrewAI Tool Fixes** | - Review tools in `backend/crew/tools/` for Pydantic v2 issues.<br>- Update models/functions for compatibility.<br>- Run `python adhd-focus-hub/test_tools.py`. | Updated tool code and passing tests. | Test script outputs success for all tools. | 1 day | ✅ Completed |
+| 3 | **Database Layer** | - Set up SQLAlchemy models (User, Task, MoodLog).<br>- Configure PostgreSQL via `DATABASE_URL`.<br>- Create Alembic migrations.<br>- Document setup in README. | Database models and migrations committed. | Migrations run without errors and tables created. | 2 days | ✅ Completed |
+| 4 | **Authentication** | - Implement JWT-based auth in FastAPI.<br>- Protect endpoints with `HTTPBearer`.<br>- Create login/register routes.<br>- Add token storage in frontend. | Auth API and middleware. | Login and protected routes work with valid tokens. | 2 days | ✅ Completed |
+| 5 | **Frontend Integration** | - Update services in `frontend/src/services` to call backend APIs with auth tokens.<br>- Build login and registration pages.<br>- Connect task and mood pages to backend. | Working frontend communicating with backend. | Users can authenticate and CRUD data from UI. | 2 days | ✅ Completed |
+| 6 | **Comprehensive Testing** | - Expand `test_tools.py` into pytest suite.<br>- Cover all API endpoints and auth flow.<br>- Add CI instructions. | Pytest tests under `tests/` directory. | Test suite passes locally and in CI. | 1.5 days | ✅ Completed |


### PR DESCRIPTION
## Summary
- renumber Orchestrator alignment and Deployment milestones so the roadmap table starts at 1
- keep completed milestones listed in the Implemented section

## Testing
- `python adhd-focus-hub/test_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68831cdffeec8329ac02073eb2b631be