### PR TITLE
Fix mood log path alignment

### DIFF
--- a/adhd-focus-hub/README.md
+++ b/adhd-focus-hub/README.md
@@ -253,6 +253,20 @@ POST /api/v1/focus/start
 ```
 
 ### Mood Tracking
+Store a mood entry and optionally request emotional support.
+
+```
+POST /api/v1/moods
+{
+  "mood_score": 6,
+  "energy_level": 4,
+  "stress_level": 8,
+  "notes": "Feeling scattered today"
+}
+```
+
+For a mood analysis without saving to your log:
+
 ```
 POST /api/v1/mood/log
 {

--- a/adhd-focus-hub/frontend/src/services/moodService.ts
+++ b/adhd-focus-hub/frontend/src/services/moodService.ts
@@ -12,11 +12,23 @@ import {
 
 export class MoodService {
   /**
-   * Log mood and get emotional support
+   * Persist a mood entry for the current user
    */
   static async logMood(request: MoodCheckRequest): Promise<MoodLogOut> {
     try {
       const response = await apiClient.post<MoodLogOut>('/api/v1/moods', request);
+      return handleApiResponse(response);
+    } catch (error) {
+      throw new Error(handleApiError(error));
+    }
+  }
+
+  /**
+   * Get mood analysis and coping suggestions using the emotion agent
+   */
+  static async checkMood(request: MoodCheckRequest): Promise<MoodCheckResponse> {
+    try {
+      const response = await apiClient.post<MoodCheckResponse>('/api/v1/mood/log', request);
       return handleApiResponse(response);
     } catch (error) {
       throw new Error(handleApiError(error));


### PR DESCRIPTION
## Summary
- run BackendDeveloper and FrontendDeveloper dev agents for alignment guidance
- clarify mood endpoints in README
- extend `MoodService` with `checkMood` method for the `/api/v1/mood/log` route

## Testing
- `python adhd-focus-hub/test_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68832a9ed9848329a8cac0554744eb0f