### PR TITLE
Add chat page to frontend

### DIFF
--- a/adhd-focus-hub/frontend/src/App.tsx
+++ b/adhd-focus-hub/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import Learning from './pages/Learning';
 import Organization from './pages/Organization';
 import Login from './pages/Login';
 import Register from './pages/Register';
+import ChatPage from './pages/Chat';
 import AIChat from './components/AIChat';
 import { AuthProvider, useAuth } from './context/AuthContext';
 import './App.css';
@@ -108,6 +109,14 @@ function App() {
                   element={
                     <RequireAuth>
                       <Organization />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path="/chat"
+                  element={
+                    <RequireAuth>
+                      <ChatPage />
                     </RequireAuth>
                   }
                 />

--- a/adhd-focus-hub/frontend/src/components/AIChat.tsx
+++ b/adhd-focus-hub/frontend/src/components/AIChat.tsx
@@ -17,11 +17,18 @@ interface Message {
 }
 
 interface AIChatProps {
-  isOpen: boolean;
-  onClose: () => void;
+  /** Whether the chat is open (for overlay mode) */
+  isOpen?: boolean;
+  /** Close handler for overlay mode */
+  onClose?: () => void;
+  /**
+   * Rendering mode: "overlay" for modal-like behavior or "page" for full page
+   * chat interface.
+   */
+  mode?: 'overlay' | 'page';
 }
 
-const AIChat: React.FC<AIChatProps> = ({ isOpen, onClose }) => {
+const AIChat: React.FC<AIChatProps> = ({ isOpen = true, onClose, mode = 'overlay' }) => {
   const [messages, setMessages] = useState<Message[]>([
     {
       id: '1',
@@ -130,10 +137,16 @@ const AIChat: React.FC<AIChatProps> = ({ isOpen, onClose }) => {
     }
   };
 
-  if (!isOpen) return null;
+  if (mode === 'overlay' && !isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div
+      className={
+        mode === 'overlay'
+          ? 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4'
+          : 'flex justify-center p-4'
+      }
+    >
       <div className="w-full max-w-2xl h-[80vh] bg-white rounded-lg shadow-xl flex flex-col">
         {/* Header */}
         <div className="p-4 border-b border-gray-200 bg-gradient-to-r from-blue-50 to-indigo-50 rounded-t-lg">
@@ -149,12 +162,14 @@ const AIChat: React.FC<AIChatProps> = ({ isOpen, onClose }) => {
               >
                 Clear
               </button>
-              <button
-                onClick={onClose}
-                className="p-2 hover:bg-white hover:bg-opacity-50 rounded-lg transition-colors"
-              >
-                <X size={20} className="text-gray-600" />
-              </button>
+              {mode === 'overlay' && onClose && (
+                <button
+                  onClick={onClose}
+                  className="p-2 hover:bg-white hover:bg-opacity-50 rounded-lg transition-colors"
+                >
+                  <X size={20} className="text-gray-600" />
+                </button>
+              )}
             </div>
           </div>
           

--- a/adhd-focus-hub/frontend/src/components/Sidebar.tsx
+++ b/adhd-focus-hub/frontend/src/components/Sidebar.tsx
@@ -7,7 +7,8 @@ import {
   Heart, 
   BookOpen, 
   Folder,
-  X 
+  MessageCircle,
+  X
 } from 'lucide-react';
 
 interface SidebarProps {
@@ -25,6 +26,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
     { path: '/mood', icon: Heart, label: 'Mood Tracking' },
     { path: '/learning', icon: BookOpen, label: 'Learning Hub' },
     { path: '/organization', icon: Folder, label: 'Organization' },
+    { path: '/chat', icon: MessageCircle, label: 'Chat Assistant' },
   ];
 
   return (

--- a/adhd-focus-hub/frontend/src/pages/Chat.tsx
+++ b/adhd-focus-hub/frontend/src/pages/Chat.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import AIChat from '../components/AIChat';
+
+const ChatPage: React.FC = () => {
+  return (
+    <div className="page">
+      <AIChat mode="page" />
+    </div>
+  );
+};
+
+export default ChatPage;


### PR DESCRIPTION
## Summary
- make `AIChat` usable as overlay or full page
- add Chat page that hosts the chat component
- register new route and sidebar link

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68832cd1d03c8329b9c566ed49913e4b