### PR TITLE
Fix tests with consistent DB imports

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,3 +36,7 @@ This roadmap should keep all agents aligned as the project progresses.
 | 4 | **Authentication** | - Implement JWT-based auth in FastAPI.<br>- Protect endpoints with `HTTPBearer`.<br>- Create login/register routes.<br>- Add token storage in frontend. | Auth API and middleware. | Login and protected routes work with valid tokens. | 2 days | ✅ Completed |
 | 5 | **Frontend Integration** | - Update services in `frontend/src/services` to call backend APIs with auth tokens.<br>- Build login and registration pages.<br>- Connect task and mood pages to backend. | Working frontend communicating with backend. | Users can authenticate and CRUD data from UI. | 2 days | ✅ Completed |
 | 6 | **Comprehensive Testing** | - Expand `test_tools.py` into pytest suite.<br>- Cover all API endpoints and auth flow.<br>- Add CI instructions. | Pytest tests under `tests/` directory. | Test suite passes locally and in CI. | 1.5 days | ✅ Completed |
+
+## Known Issues
+
+- **Database module imports**: The application imports `database` while tests imported `backend.database`, creating two separate SQLAlchemy `Base` instances. This caused tables to be missing during tests. Tests were updated to import from `database`, but backend modules should standardize on a single package path.

--- a/adhd-focus-hub/backend/pyproject.toml
+++ b/adhd-focus-hub/backend/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "psutil>=5.9.8",
     "aiofiles>=23.2.1",
+    "aiosqlite>=0.21.0",
 ]
 
 [project.optional-dependencies]

--- a/adhd-focus-hub/backend/requirements.txt
+++ b/adhd-focus-hub/backend/requirements.txt
@@ -16,3 +16,4 @@ jinja2==3.1.6
 python-dotenv==1.0.1
 psutil==6.1.0
 aiofiles==24.1.0
+aiosqlite==0.21.0

--- a/adhd-focus-hub/tests/test_api.py
+++ b/adhd-focus-hub/tests/test_api.py
@@ -6,7 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 os.environ["DATABASE_URL"] = "sqlite+aiosqlite:////tmp/test.db"
 
 from backend.api.main import app, get_db
-from backend.database import Base, engine, SessionLocal
+# Import database objects using the same module path as the application.
+# The app imports `database.models`, so we need to use the same package to
+# ensure the SQLAlchemy Base instance is shared during testing.
+from database import Base, engine, SessionLocal
 
 
 @pytest.fixture(autouse=True, scope="module")


### PR DESCRIPTION
## Summary
- ensure tests import DB modules from the same package as the app
- add `aiosqlite` to backend dependencies
- document database import issue in ROADMAP

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_68838ea1400883299f349febb1fd94fb