### PR TITLE
Add Codex installation helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,11 @@ Before running any agents, set your `OPENAI_API_KEY` environment variable:
 export OPENAI_API_KEY=your_openai_api_key
 ```
 
+If the `codex` command is missing, run the helper script to install it:
+```bash
+./scripts/install_codex.sh
+```
+
 Start Codex with any combination of these agents. Example:
 ```bash
 codex agents start LeadPlanner BackendDeveloper FrontendDeveloper QATester DocsWriter

--- a/adhd-focus-hub/README.md
+++ b/adhd-focus-hub/README.md
@@ -309,6 +309,7 @@ npm run lint
 ## Development Agents
 
 See [AGENT.md](../AGENT.md) for a list of Codex development agents, how to start them, and example workflows.
+If the `codex` CLI isn't installed, execute `./scripts/install_codex.sh` from the repository root.
 
 ## 🚀 Deployment
 

--- a/scripts/install_codex.sh
+++ b/scripts/install_codex.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Install the Codex CLI if it isn't already available.
+set -e
+if command -v codex > /dev/null 2>&1; then
+  echo "Codex CLI already installed." >&2
+  exit 0
+fi
+
+echo "Attempting to install Codex CLI..."
+# Try official repository first; fall back to open-codex if unavailable.
+if ! pip install --quiet git+https://github.com/smol-ai/codex.git; then
+  echo "GitHub install failed, falling back to PyPI open-codex package." >&2
+  pip install --quiet open-codex
+fi
+
+echo "Codex installation attempt complete."


### PR DESCRIPTION
## Summary
- add `install_codex.sh` to install the Codex CLI
- document using the script in `AGENTS.md`
- reference the install script in `adhd-focus-hub/README.md`

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_688394b7844c8329842f82c1306cac87