### PR TITLE
Remove explicit test run instruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,11 +85,3 @@ Below is the current development plan. Each agent should focus on the tasks in t
 - Describe the testing process and how development agents should run `python adhd-focus-hub/test_tools.py`.
 - Provide a brief guide on using the development agents defined in this file and `DEV_AGENTS.md`.
 
-## Testing
-
-After code changes, run:
-```bash
-python adhd-focus-hub/test_tools.py
-```
-Include the output of this script in your pull request summary.
-


### PR DESCRIPTION
## Summary
- remove the "After code changes" testing instructions from AGENTS.md

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6883c8da9a248329a4e4540f61badc06