### PR TITLE
Add Docker deployment architecture design

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ Each milestone is ordered by priority with an estimated time to complete.
 
 | Priority | Milestone | Key Tasks | Deliverables | Success Criteria | Est. Time | Status |
 |---------|----------|-----------|--------------|-----------------|-----------|--------|
-| 1 | **Deployment** | - Create Docker compose for backend/frontend.<br>- Document deployment steps.<br>- Push images to container registry. | Dockerfiles and compose config for production. | Application deploys successfully on staging environment. | 1.5 days | ⏳ Pending |
+| 1 | **Deployment** | - Create Docker compose for backend/frontend.<br>- Document Docker architecture and deployment steps.<br>- Push images to container registry. | Dockerfiles and compose config for production. | Application deploys successfully on staging environment. | 1.5 days | ⏳ Pending |
 | 2 | **Frontend-Backend Alignment** | - Audit API endpoints and React services.<br>- Resolve route mismatches such as mood logging.<br>- Document the final API contract. | Unified interface between layers. | Frontend calls all endpoints without errors. | 0.5 day | ⏳ Pending |
 | 3 | **Organization & Learning Endpoints** | - Implement `/api/v1/organize` and `/api/v1/learn` routes.<br>- Add services in React.<br>- Write tests for endpoints. | Endpoints with frontend services. | Users access organization and learning help via UI. | 1 day | ⏳ Pending |
 | 4 | **Redis Integration** | - Connect to Redis via `REDIS_URL`.<br>- Persist conversation history.<br>- Document caching setup. | Redis-backed caching layer. | History survives restarts. | 1 day | ⏳ Pending |

--- a/adhd-focus-hub/design/docker_architecture.md
+++ b/adhd-focus-hub/design/docker_architecture.md
@@ -1,0 +1,49 @@
+# Docker-Based Deployment Architecture
+
+This document describes how the backend and frontend services are deployed using Docker.
+
+## Overview
+
+We use **Docker Compose** to orchestrate four main services:
+
+1. **backend** – FastAPI application built from `backend/Dockerfile`.
+2. **frontend** – React application built from `frontend/Dockerfile`.
+3. **postgres** – PostgreSQL database for persistent storage.
+4. **redis** – Redis cache used for conversation history.
+
+Two compose files are provided:
+
+- `docker-compose.yml` – optimized for local development with volume mounts and automatic reload.
+- `docker-compose.production.yml` – builds versioned images for production deployments.
+
+## Local Development
+
+Run:
+
+```bash
+docker compose up --build
+```
+
+The development compose file mounts the source code so changes are immediately reflected. The backend runs with `uvicorn --reload` and the frontend with `npm start`.
+
+## Production Deployment
+
+The production compose file builds minimal images and starts containers without volume mounts. Environment variables control secrets and connection URLs. Example:
+
+```bash
+docker compose -f docker-compose.production.yml up --build -d
+```
+
+Images can be pushed to a container registry and reused across environments.
+
+## Networking
+
+All services share an internal network created by Docker Compose. The frontend communicates with the backend on port `8000`, while the backend talks to PostgreSQL and Redis on their default ports. Ports `3000`, `8000`, `5432`, and `6379` are published for external access.
+
+## Persistence
+
+Database and cache data are stored in Docker volumes (`postgres_data`, `redis_data`). These volumes survive container restarts to preserve user data and cached history.
+
+---
+
+This architecture provides a repeatable way to run the application locally and in production while isolating dependencies and simplifying deployment steps.


### PR DESCRIPTION
## Summary
- document Docker-based deployment architecture in `design/docker_architecture.md`
- refine roadmap deployment milestone to mention Docker architecture documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fa7f3c88832997194d09cef012b3