### PR TITLE
Add compose files and run scripts

### DIFF
--- a/adhd-focus-hub/README.md
+++ b/adhd-focus-hub/README.md
@@ -94,7 +94,7 @@ cp .env.example .env
 # Edit .env with your configuration
 
 # Start all services
-docker-compose up --build
+../scripts/dev_compose.sh
 ```
 
 The application will be available at:
@@ -106,7 +106,8 @@ The default `docker-compose.yml` is optimized for local development. It mounts
 the source code into the containers and enables automatic reloads when files
 change. For a production deployment, use
 `docker-compose.production.yml` which builds the images once and runs them
-without any source-code volumes. All configuration values should be supplied via
+without any source-code volumes. You can start it with
+`../scripts/prod_compose.sh`. All configuration values should be supplied via
 environment variables.
 
 ## 🏗️ Project Structure
@@ -311,7 +312,7 @@ npm run lint
 ### Docker Production
 ```bash
 # Build and run production containers
-docker-compose -f docker-compose.production.yml up --build -d
+../scripts/prod_compose.sh
 ```
 This compose file uses the Docker images defined in the repository and does not
 mount the application source code. Provide all secrets and URLs through

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,54 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./adhd-focus-hub/frontend
+      dockerfile: Dockerfile
+    image: adhd_focus_hub_frontend:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=${REACT_APP_API_URL}
+      - REACT_APP_VERSION=${REACT_APP_VERSION:-1.0.0}
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./adhd-focus-hub/backend
+      dockerfile: Dockerfile
+    image: adhd_focus_hub_backend:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=${DATABASE_URL}
+      - REDIS_URL=${REDIS_URL}
+      - SECRET_KEY=${SECRET_KEY}
+      - ENVIRONMENT=production
+    depends_on:
+      - postgres
+      - redis
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB:-adhd_focus_hub}
+      - POSTGRES_USER=${POSTGRES_USER:-postgres}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-password}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./adhd-focus-hub/frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - REACT_APP_API_URL=http://localhost:8000
+      - REACT_APP_VERSION=1.0.0
+    depends_on:
+      - backend
+    volumes:
+      - ./adhd-focus-hub/frontend:/app
+      - /app/node_modules
+
+  backend:
+    build:
+      context: ./adhd-focus-hub/backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:password@postgres:5432/adhd_focus_hub}
+      - REDIS_URL=${REDIS_URL:-redis://redis:6379}
+      - SECRET_KEY=${SECRET_KEY:-your-secret-key-change-in-production}
+      - ENVIRONMENT=${ENVIRONMENT:-development}
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - ./adhd-focus-hub/backend:/app
+    command: uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
+
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      - POSTGRES_DB=adhd_focus_hub
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./adhd-focus-hub/backend/database/init.sql:/docker-entrypoint-initdb.d/init.sql
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/scripts/dev_compose.sh
+++ b/scripts/dev_compose.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Run the local development stack using Docker Compose.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+docker compose up --build

--- a/scripts/prod_compose.sh
+++ b/scripts/prod_compose.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Build and run the production stack using Docker Compose.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+docker compose -f docker-compose.production.yml up --build -d


### PR DESCRIPTION
## Summary
- add repository-level `docker-compose.yml` and `docker-compose.production.yml`
- provide helper scripts to start local and production stacks
- document script usage in README

## Testing
- `python adhd-focus-hub/test_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6883feef18848329bceef81537a0dbfb