### PR TITLE
Add Redis caching for conversation history

### DIFF
--- a/adhd-focus-hub/backend/database/models.py
+++ b/adhd-focus-hub/backend/database/models.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from datetime import datetime
-from sqlalchemy import Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy import Integer, String, Boolean, DateTime, ForeignKey, Text, JSON
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
+
 
 class User(Base):
     __tablename__ = "users"
@@ -16,6 +17,7 @@ class User(Base):
 
     tasks: Mapped[list[Task]] = relationship("Task", back_populates="owner")
     moods: Mapped[list[MoodLog]] = relationship("MoodLog", back_populates="owner")
+
 
 class Task(Base):
     __tablename__ = "tasks"
@@ -29,6 +31,7 @@ class Task(Base):
 
     owner: Mapped[User] = relationship("User", back_populates="tasks")
 
+
 class MoodLog(Base):
     __tablename__ = "mood_logs"
 
@@ -39,3 +42,16 @@ class MoodLog(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
     owner: Mapped[User] = relationship("User", back_populates="moods")
+
+
+class ConversationHistory(Base):
+    __tablename__ = "conversation_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    message: Mapped[str] = mapped_column(Text)
+    response: Mapped[str] = mapped_column(Text)
+    metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    user: Mapped[User | None] = relationship("User")

--- a/adhd-focus-hub/backend/migrations/versions/0002_conversation_history.py
+++ b/adhd-focus-hub/backend/migrations/versions/0002_conversation_history.py
@@ -1,0 +1,25 @@
+"""add conversation_history table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversation_history",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=True),
+        sa.Column("message", sa.Text, nullable=False),
+        sa.Column("response", sa.Text, nullable=False),
+        sa.Column("metadata_json", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("conversation_history")

--- a/adhd-focus-hub/backend/services/cache.py
+++ b/adhd-focus-hub/backend/services/cache.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from redis.asyncio import Redis
+
+from config.settings import get_settings
+
+settings = get_settings()
+
+redis_client = Redis.from_url(settings.redis_url, decode_responses=True)
+
+CACHE_LIMIT = int(os.getenv("CONVERSATION_CACHE_LIMIT", "50"))
+CACHE_TTL = int(os.getenv("CONVERSATION_CACHE_TTL", str(60 * 60 * 24)))
+
+
+def _key(user_id: Optional[int]) -> str:
+    return f"conversation:{user_id or 'anon'}"
+
+
+async def push_history(user_id: Optional[int], record: Dict[str, Any]) -> None:
+    key = _key(user_id)
+    await redis_client.lpush(key, json.dumps(record))
+    await redis_client.ltrim(key, 0, CACHE_LIMIT - 1)
+    await redis_client.expire(key, CACHE_TTL)
+
+
+async def get_history(
+    user_id: Optional[int], limit: int = CACHE_LIMIT
+) -> List[Dict[str, Any]]:
+    key = _key(user_id)
+    data = await redis_client.lrange(key, 0, limit - 1)
+    return [json.loads(d) for d in data]


### PR DESCRIPTION
## Summary
- add ConversationHistory model and migration
- log conversations to Postgres and Redis
- implement async Redis cache helper
- test that chat interactions persist to history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884102d35988329b93869fdaf96fba9